### PR TITLE
fix K2COMPAT_PURGE_DUMMYPROP_LOG not working.

### DIFF
--- a/data/k2compat/k2compat.tjs
+++ b/data/k2compat/k2compat.tjs
@@ -143,8 +143,9 @@ class Krkr2CompatUtils {
 				(@"property ${key} { getter { return typeof this.${prefix}${key} != 'undefined' ? this.${prefix}${key} : ${value}; }" +
 				 @"setter(v) { this.${prefix}${key} = v;"
 				 @if (! K2COMPAT_PURGE_DUMMYPROP_LOG)
-				 + @"global.Debug.message('Krkr2CompatUtils: dummy property ${key} set', v, Scripts.getTraceString()); } }"
+				 + @"global.Debug.message('Krkr2CompatUtils: dummy property ${key} set', v, Scripts.getTraceString());"
 				 @endif
+				 +  "} }"
 				 )!;
 			} incontextof cls)(key, value, "_k2compat_");
 		}


### PR DESCRIPTION
 K2COMPAT_PURGE_DUMMYPROP_LOG に1を設定すると、文字列で設定している文の末尾を正しく閉じていないため、エラーになっていた問題を修正しました。
